### PR TITLE
Add screen size adjustment

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -19,7 +19,8 @@ h1,
 h2,
 h3,
 h4,
-.brand {
+.brand,
+.navbar {
   font-family: Nunito;
 }
 
@@ -66,6 +67,14 @@ img {
 
 .navbar .nav-item {
   margin-left: 1.5rem;
+}
+
+.navbar .screen-size input {
+  background: rgba(255, 255, 255, 0.1);
+  color: inherit;
+  width: 4em;
+  border: 0;
+  border-bottom: 2px solid rgba(255, 255, 255, 0.5);
 }
 
 .nav-icon img {
@@ -145,17 +154,28 @@ button:active {
 }
 
 #remote-screen {
-  max-width: 85%;
-  max-height: 1080px;
+  width: 1920px;
+  max-width: 85%; /* Keep for back-compat */
+  max-width: 85vw;
   margin-left: auto;
   margin-right: auto;
-  padding-left: 1rem;
-  padding-right: 1rem;
 }
 
+#remote-screen-sizer {
+  width: 100%;
+  padding-top: 56.25%; /* Default to 1920/1080 * 100 */
+  position: relative;
+}
 #remote-screen img {
   width: 100%;
+  height: 100%;
   cursor: crosshair;
+  object-fit: cover;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
 }
 
 .keyboard-status {

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -309,6 +309,19 @@ function emitMouseEvent(domTarget, position, buttons) {
   });
 }
 
+function configureScreenSize(evt) {
+  if (evt !== undefined) {
+    evt.stopPropagation();
+  }
+
+  const target =
+    document.getElementById("screen-size-x").value /
+    document.getElementById("screen-size-y").value;
+
+  const sizer = document.getElementById("remote-screen-sizer");
+  sizer.style.paddingTop = 100 / target + "%";
+}
+
 function onKeyUp(evt) {
   keyState[evt.keyCode] = false;
   if (!connectedToServer) {
@@ -365,6 +378,14 @@ document.getElementById("fullscreen-btn").addEventListener("click", () => {
 document.getElementById("hide-error-btn").addEventListener("click", () => {
   hideElementById("error-panel");
 });
+["change", "keyup", "keydown"].forEach(function (event) {
+  document
+    .getElementById("screen-size-x")
+    .addEventListener(event, configureScreenSize);
+  document
+    .getElementById("screen-size-y")
+    .addEventListener(event, configureScreenSize);
+});
 document
   .getElementById("confirm-shutdown")
   .addEventListener("click", function () {
@@ -385,4 +406,9 @@ socket.on("connect", onSocketConnect);
 socket.on("disconnect", onSocketDisconnect);
 socket.on("keystroke-received", (keystrokeResult) => {
   updateKeyStatus(keystrokeResult.keystrokeId, keystrokeResult.success);
+});
+
+window.addEventListener("load", function () {
+  // The browser automatically remembers input values ~> reload them
+  configureScreenSize();
 });

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -19,6 +19,12 @@
       <div class="navbar">
         <p class="brand">TinyPilot</p>
         <div class="nav-items">
+          <div class="nav-item screen-size">
+            <span>Screen size</span>
+            <input type="text" id="screen-size-x" value="1920" />
+            <span>x</span>
+            <input type="text" id="screen-size-y" value="1080" />
+          </div>
           <div class="nav-item fullscreen">
             <button id="fullscreen-btn">Fullscreen</button>
           </div>
@@ -79,7 +85,9 @@
           <button id="cancel-shutdown" class="btn" type="button">Cancel</button>
         </div>
         <div id="remote-screen">
-          <img id="remote-screen-img" src="/stream?advance_headers=1" />
+          <div id="remote-screen-sizer">
+            <img id="remote-screen-img" src="/stream?advance_headers=1" />
+          </div>
         </div>
         <div id="keystroke-history" class="container">
           <div id="recent-keys"></div>


### PR DESCRIPTION
(Based on https://github.com/mtlynch/tinypilot/pull/177)

Some devices I tried this on didn't have a 1920x1080 resolution (as it's mirroring another screen). This translates to a 1920x1080 stream with black bars on the side (the real screen being 1680x1050). This PR would enable the override of the size which would cut off the black bars & fix the mouse positions.

Leaving this as a draft PR as it's a bit hacky approach-wise (couldn't find a sane way of detecting the "real" resolution). Thoughts on the approach/problem?